### PR TITLE
Fix compound, honeycomb and ominous_bottle ids

### DIFF
--- a/required_item_list.json
+++ b/required_item_list.json
@@ -1220,7 +1220,7 @@
         "component_based": false
     },
     "minecraft:compound": {
-        "runtime_id": 616,
+        "runtime_id": 614,
         "component_based": false
     },
     "minecraft:compound_creator": {
@@ -3256,7 +3256,7 @@
         "component_based": false
     },
     "minecraft:honeycomb": {
-        "runtime_id": 612,
+        "runtime_id": 616,
         "component_based": false
     },
     "minecraft:honeycomb_block": {
@@ -4584,7 +4584,7 @@
         "component_based": false
     },
     "minecraft:ominous_bottle": {
-        "runtime_id": 614,
+        "runtime_id": 612,
         "component_based": false
     },
     "minecraft:ominous_trial_key": {


### PR DESCRIPTION
In fact, in the latest version, these elements should have exactly these IDs. Check the generator of this file or try regenerate from release version if it can fix it.